### PR TITLE
Include installation via package managers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,21 @@ Nextinspace is a command-line tool for seeing the latest in space! Nextinspace w
 
 ## Installation
 
+To install nextinspace, simply run:
 ```bash
 pip install nextinspace
+
+# directly from Github
+pip install git+https://github.com/The-Kid-Gid/nextinspace
 ```
 
-If you want to install it from Github, use:
-
+Or use your favourite package manager:
 ```bash
-pip install git+https://github.com/The-Kid-Gid/nextinspace
+# Arch Linux
+yay -S nextinspace
+
+# Nix
+nix-env -iA nixpkgs.nextinspace
 ```
 
 ## Usage


### PR DESCRIPTION
Hey there o/

`nextinspace` is such a nifty tool :smile: using it almost every day

Just wanted to let you know that the Nix package manager now includes nextinspace (ref Nixos/nixpkgs#101922). The updated README adds the arch linux and nix package to the installation section, in case you want it in there.