### PR TITLE
Don't install LICENSE file in site-diretory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Natural Language :: English"
 ]
-include = ["LICENSE"]
+include = [
+  {path = "LICENSE", format = "sdist"}
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
When packaging nextinspace for Gentoo it came to light, that the poetry build system tries to install the license file to the python site directory (see https://github.com/gentoo/gentoo/pull/39782#discussion_r1892778496). This patch includes the file only in source packages as advised by https://projects.gentoo.org/python/guide/qawarn.html#documentation-files-installed-by-poetry.